### PR TITLE
Docs: elaborate on JSON usage

### DIFF
--- a/src/content/docs/getting-started/basic-usage.mdx
+++ b/src/content/docs/getting-started/basic-usage.mdx
@@ -502,6 +502,18 @@ void SendComplexData() {
 ```
 
 </TabItem>
+<TabItem label="JavaScript from C++">
+
+```js
+var my_data;    // defined outside function for persistance
+
+window.updateComplexData = (data) => {
+  my_data = data;
+  console.log(my_data.name);      // expect "Dragonborn", as defined in C++ example
+};
+```
+
+</TabItem>
 <TabItem label="JavaScript to C++">
 
 ```js

--- a/src/content/docs/getting-started/basic-usage.mdx
+++ b/src/content/docs/getting-started/basic-usage.mdx
@@ -496,7 +496,7 @@ void SendComplexData() {
         }}
     };
 
-    std::string script = "updateComplexData('" + playerData.dump() + "')";
+    std::string script = "updateComplexData(" + playerData.dump() + ")";
     PrismaUI->Invoke(view, script.c_str());
 }
 ```


### PR DESCRIPTION
This PR corrects an invalid single-quote use, and elaborates with an example how to catch an object sent from the C++ side.